### PR TITLE
label: add "good first issue"

### DIFF
--- a/tasks/labels.json
+++ b/tasks/labels.json
@@ -28,6 +28,10 @@
         "color": "159818"
     },
     {
+        "name": "good first issue",
+        "color": "0f3df7"
+    },
+    {
         "name": "invalid",
         "color": "e6e6e6"
     },


### PR DESCRIPTION
When we add the label "good first issue", Github makes them show up on a special page, allowing newcomers to more easily jump in.

Examples:

- https://github.com/vercel/next.js/contribute
- https://github.com/metaplex-foundation/metaplex-program-library/contribute

@austbot Please rerun your sync script after this lands.